### PR TITLE
Fix: batch IP geolocation requests (limit 100), add deduplication and caching

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1075,23 +1075,36 @@ def API_GetPeerHistoricalEndpoints():
     if not configurationName or not id:
         return ResponseObject(False, "Please provide configurationName and id")
     fp, p = WireguardConfigurations.get(configurationName).searchPeer(id)
-    if fp:
-        result = p.getEndpoints()
-        geo = {}
-        try:
-            r = requests.post(f"http://ip-api.com/batch?fields=city,country,lat,lon,query",
-                              data=json.dumps([x['endpoint'] for x in result]))
-            d = r.json()
-            
-                
-        except Exception as e:
-            return ResponseObject(data=result, message="Failed to request IP address geolocation. " + str(e))
-        
-        return ResponseObject(data={
-            "endpoints": p.getEndpoints(),
-            "geolocation": d
-        })
-    return ResponseObject(False, "Peer does not exist")
+    if not fp:
+        return ResponseObject(False, "Peer does not exist")
+    endpoints = p.getEndpoints()
+    ips = [x['endpoint'] for x in endpoints]
+    unique_ips = list(set(ips))
+    def chunks(lst, size=100):
+        for i in range(0, len(lst), size):
+            yield lst[i:i + size]
+    geo_cache = {}
+    try:
+        for batch in chunks(unique_ips, 100):
+            r = requests.post(
+                "http://ip-api.com/batch?fields=city,country,lat,lon,query",
+                data=json.dumps(batch),
+                timeout=5
+            )
+            r.raise_for_status()
+            data = r.json()
+            for item in data:
+                geo_cache[item["query"]] = item
+        geolocation = [geo_cache[ip] for ip in ips]
+    except Exception as e:
+        return ResponseObject(
+            data={"endpoints": endpoints},
+            message="Failed to request IP address geolocation. " + str(e)
+        )
+    return ResponseObject(data={
+        "endpoints": endpoints,
+        "geolocation": geolocation
+    })
 
 @app.get(f'{APP_PREFIX}/api/getPeerSessions')
 def API_GetPeerSessions():


### PR DESCRIPTION
## Summary

This PR fixes intermittent failures in the `/api/getPeerHistoricalEndpoints` endpoint caused by `ip-api.com` rejecting batch requests containing more than 100 IPs.  
The updated implementation introduces batching, deduplication, caching, and stable ordering of results.

---

## Changes

### Added
- Batching of IP addresses into chunks of **100** to comply with ip-api limits  
- Deduplication of repeated IPs before sending requests  
- In‑memory cache to avoid repeated lookups for identical IPs  
- Reconstruction of the geolocation list in the **original order and length**

### Improved
- Error handling around external API failures  
- Code readability and maintainability  

### Preserved
- API response structure  
- Order and count of geolocation entries  

---

## Motivation

`ip-api.com` enforces a strict limit of **100 IPs per batch request**.  
Peers with large historical endpoint lists occasionally exceeded this limit, causing:

- Random API failures  
- Unhandled exceptions  
- Inconsistent API responses  

This PR ensures the endpoint behaves predictably and efficiently even with large datasets.

---

##  Impact

- Eliminates random failures due to API limits  
- Reduces number of external requests  
- Improves performance for peers with many repeated endpoints  
- Makes the endpoint more robust and predictable  