### PR TITLE
Fix peer tracking disabled by default; include endpoint history in backup/restore

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -96,7 +96,6 @@ def peerInformationBackgroundThread():
                             c.getPeersEndpoint()
                             c.getPeers()
                             if DashboardConfig.GetConfig('WireGuardConfiguration', 'peer_tracking')[1] is True:
-                                print("[WGDashboard] Tracking Peers")
                                 if delay == 6:
                                     if c.configurationInfo.PeerTrafficTracking:
                                         c.logPeersTraffic()

--- a/src/modules/DashboardConfig.py
+++ b/src/modules/DashboardConfig.py
@@ -83,7 +83,7 @@ class DashboardConfig:
             },
             "WireGuardConfiguration": {
                 "autostart": "",
-                "peer_tracking": "false"
+                "peer_tracking": "true"
             }
         }
 

--- a/src/modules/WireguardConfiguration.py
+++ b/src/modules/WireguardConfiguration.py
@@ -232,7 +232,7 @@ class WireguardConfiguration:
             self.Status = self.getStatus()
 
     def __dropDatabase(self):
-        existingTables = [self.Name, f'{self.Name}_restrict_access', f'{self.Name}_transfer', f'{self.Name}_deleted']
+        existingTables = [self.Name, f'{self.Name}_restrict_access', f'{self.Name}_transfer', f'{self.Name}_deleted', f'{self.Name}_history_endpoint']
         try:
             with self.engine.begin() as conn:
                 for t in existingTables:
@@ -308,7 +308,8 @@ class WireguardConfiguration:
             f'{dbName}_history_endpoint', self.metadata,
             sqlalchemy.Column('id', sqlalchemy.String(255), nullable=False),
             sqlalchemy.Column('endpoint', sqlalchemy.String(255), nullable=False),
-            sqlalchemy.Column('time', time_col_type)
+            sqlalchemy.Column('time', time_col_type),
+            extend_existing=True
         )
         
         self.infoTable = sqlalchemy.Table(
@@ -322,7 +323,7 @@ class WireguardConfiguration:
 
     def __dumpDatabase(self):
         with self.engine.connect() as conn:
-            tables = [self.peersTable, self.peersRestrictedTable, self.peersTransferTable, self.peersDeletedTable]
+            tables = [self.peersTable, self.peersRestrictedTable, self.peersTransferTable, self.peersDeletedTable, self.peersHistoryEndpointTable]
             for i in tables:
                 rows = conn.execute(i.select()).mappings().fetchall()
                 for row in rows:


### PR DESCRIPTION
Fixes #1275

## Root cause

Commit `40e2ddc` introduced a global `peer_tracking` config gate in the background thread. Its default value was set to `"false"`, which silently disabled both traffic and endpoint history recording for all new installs and for any upgrade where the key did not yet exist in the config file. Prior to that commit, tracking was always active and governed only by the per-configuration `PeerTrafficTracking` and `PeerHistoricalEndpointTracking` flags, which both default to `True`.

## Changes

**`src/modules/DashboardConfig.py`**
Change the default for `peer_tracking` from `"false"` to `"true"`. Existing installs with an explicit value already written to their config file are unaffected.

**`src/modules/WireguardConfiguration.py`**
- Add `extend_existing=True` to `peersHistoryEndpointTable`. Without it, calling `createDatabase()` more than once on the same `metadata` instance — which happens on every `restoreBackup()` call — raises `InvalidRequestError` for this table while all others succeed silently. Every other table definition in `createDatabase()` already carries this flag.
- Add `_history_endpoint` to `__dropDatabase()` so stale rows are cleared before a restore, consistent with the other tables.
- Add `peersHistoryEndpointTable` to `__dumpDatabase()` so endpoint history is included in backup files and survives backup/restore cycles. Previously it was permanently lost on every backup.

**`src/dashboard.py`**
Remove a `print()` statement that fired every 10 seconds per active configuration once tracking is enabled.

## Backward compatibility

No schema changes. No API changes. Users who explicitly disabled `peer_tracking` via the Settings UI are unaffected — their value is already persisted in the config file and the default only applies when the key is absent.

## Test plan

- Confirm `peer_tracking = true` is written to config on a fresh install and that peer rows accumulate in `_transfer` and `_history_endpoint` after ~60 seconds with an active peer
- Confirm an existing install with `peer_tracking = false` continues to have tracking disabled after restart
- Create a backup, verify the `.sql` file contains `INSERT` statements for `_history_endpoint`, restore the backup, confirm endpoint history is present and was cleared before restore