### PR TITLE
Fix Python 3.11 SyntaxError in AmneziaPeer.py

### DIFF
--- a/src/modules/AmneziaPeer.py
+++ b/src/modules/AmneziaPeer.py
@@ -87,8 +87,9 @@ class AmneziaPeer(Peer):
 
             if psk_exist: os.remove(uid)
 
-            if len(updateAllowedIp.decode().strip("\n")) != 0:
-                current_app.logger.error(f"Update peer failed when updating Allowed IPs.\nInput: {newAllowedIPs}\nOutput: {updateAllowedIp.decode().strip('\n')}")
+            output = updateAllowedIp.decode().strip("\n")
+            if len(output) != 0:
+                current_app.logger.error(f"Update peer failed when updating Allowed IPs.\nInput: {newAllowedIPs}\nOutput: {output}")
                 return False, "Internal server error"
 
             command = [f"{self.configuration.Protocol}-quick", "save", self.configuration.Name]


### PR DESCRIPTION
On Python 3.11, `src/modules/AmneziaPeer.py` raises `SyntaxError: f-string expression part cannot include a backslash` at line 91 because `strip('\n')` sits inside the f-string `{...}`. PEP 701 lifted the backslash restriction starting in 3.12, so 3.12+ runs unaffected.

Reproduced under 3.11:
```
$ python3.11 -c "import ast, pathlib; ast.parse(pathlib.Path('src/modules/AmneziaPeer.py').read_text())"
SyntaxError: f-string expression part cannot include a backslash
```

The fix binds `updateAllowedIp.decode().strip("\n")` to a local before the f-string, which also removes the duplicate decode+strip already performed on the preceding length check.

Closes #1289