### PR TITLE
Bug fix. Remove redundant break statement in IP allocation loop.

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -997,7 +997,6 @@ def API_addPeers(configName):
                             for ip in availableIps[subnet]:
                                 allowed_ips = [ip]
                                 break
-                            break  
                     else:
                         return ResponseObject(False, "No more available IP can assign") 
 


### PR DESCRIPTION
There is some bug i discover. When ask for new peer thru API, it always get only one addr, but i had IPv4 and IPv6 subnets. Then i discover there is useless break in for loop, it just take first element and quits.