### PR TITLE
fix: addPeers uses OverridePeerSettings for DNS and AllowedIPs fallback

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -880,8 +880,14 @@ def API_addPeers(configName):
             allowed_ips: list[str] = data.get('allowed_ips', [])
             allowed_ips_validation: bool = data.get('allowed_ips_validation', True)
             
-            endpoint_allowed_ip: str = data.get('endpoint_allowed_ip', DashboardConfig.GetConfig("Peers", "peer_endpoint_allowed_ip")[1])
-            dns_addresses: str = data.get('DNS', DashboardConfig.GetConfig("Peers", "peer_global_DNS")[1])
+            config = WireguardConfigurations.get(configName)
+            _ovr = config.configurationInfo.OverridePeerSettings if config.configurationInfo else None
+            endpoint_allowed_ip: str = data.get('endpoint_allowed_ip',
+                (_ovr.EndpointAllowedIPs if _ovr and _ovr.EndpointAllowedIPs else None)
+                or DashboardConfig.GetConfig("Peers", "peer_endpoint_allowed_ip")[1])
+            dns_addresses: str = data.get('DNS',
+                (_ovr.DNS if _ovr and _ovr.DNS else None)
+                or DashboardConfig.GetConfig("Peers", "peer_global_DNS")[1])
             
             
             mtu: int = data.get('mtu', None)
@@ -908,7 +914,6 @@ def API_addPeers(configName):
                 else:
                     keep_alive = 0
             
-            config = WireguardConfigurations.get(configName)
             if not config.getStatus():
                 config.toggleConfiguration()
             ipStatus, availableIps = config.getAvailableIP(-1)

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -896,7 +896,8 @@ def API_addPeers(configName):
             preshared_key: str = data.get('preshared_key', "")            
     
             if type(mtu) is not int or mtu < 0 or mtu > 1460:
-                default: str = DashboardConfig.GetConfig("Peers", "peer_mtu")[1]
+                _mtu = str(_ovr.MTU) if _ovr and _ovr.MTU else None
+                default: str = _mtu or DashboardConfig.GetConfig("Peers", "peer_mtu")[1]
                 if default.isnumeric():
                     try:
                         mtu = int(default)
@@ -905,7 +906,8 @@ def API_addPeers(configName):
                 else:
                     mtu = 0
             if type(keep_alive) is not int or keep_alive < 0:
-                default = DashboardConfig.GetConfig("Peers", "peer_keep_alive")[1]
+                _ka = str(_ovr.PersistentKeepalive) if _ovr and _ovr.PersistentKeepalive else None
+                default = _ka or DashboardConfig.GetConfig("Peers", "peer_keep_alive")[1]
                 if default.isnumeric():
                     try:
                         keep_alive = int(default)


### PR DESCRIPTION
When adding a peer via the API without explicit DNS or endpoint_allowed_ip values, the endpoint fell back directly to global wg-dashboard.ini defaults, ignoring any per-configuration OverridePeerSettings. This caused new peers to be stored with the wrong DNS and AllowedIPs in the database even when the configuration had overrides set.

Resolve by fetching the configuration's OverridePeerSettings before the global defaults. The priority is now: request body → OverridePeerSettings → global default. The existing config lookup that happened later in the function is removed as it is now done earlier.

Note: downloadPeer already applied OverridePeerSettings at download time, so client configs were correct; only the stored peer data was affected.

Fixes https://github.com/WGDashboard/WGDashboard/issues/1311