### PR TITLE
fix: add button type to accountSettingsInputPassword submission button

### DIFF
--- a/src/static/app/src/components/settingsComponent/accountSettingsInputPassword.vue
+++ b/src/static/app/src/components/settingsComponent/accountSettingsInputPassword.vue
@@ -130,6 +130,7 @@ export default {
 				</div>
 			</div>
 			<button
+                type="button"
 				:disabled="!this.passwordValid"
 				class="ms-auto btn bg-success-subtle text-success-emphasis border-1 border-success-subtle rounded-3 shadow-sm" @click="this.useValidation()">
 				<i class="bi bi-save2-fill me-2"></i>


### PR DESCRIPTION
Changing the admin password via Settings > Account Settings works in Chrome but fails in Firefox. In Firefox, clicking Save (or pressing Enter) reloads the page; the POST /api/updateDashboardConfigurationItem is aborted before reaching the backend, so the password is never updated. The Gunicorn access log shows no corresponding POST, confirming the request dies client-side.

This PR fixes this specific behavior for this specific button, but there may be other buttons with the same issue in Firefox.