### PR TITLE
Fix: backup regex, SQL cleanup, and restore metadata conflict

### DIFF
--- a/src/modules/WireguardConfiguration.py
+++ b/src/modules/WireguardConfiguration.py
@@ -984,7 +984,11 @@ class WireguardConfiguration:
         if backupFileName not in backups:
             return False
         try:
-            os.remove(os.path.join(self.__getProtocolPath(), 'WGDashboard_Backup', backupFileName))
+            backupPath = os.path.join(self.__getProtocolPath(), 'WGDashboard_Backup')
+            for ext in ('.conf', '.sql'):
+                f = os.path.join(backupPath, os.path.splitext(backupFileName)[0] + ext)
+                if os.path.exists(f):
+                    os.remove(f)
         except Exception as e:
             return False
         return True

--- a/src/modules/WireguardConfiguration.py
+++ b/src/modules/WireguardConfiguration.py
@@ -942,8 +942,8 @@ class WireguardConfiguration:
         files.sort(key=lambda x: x[1], reverse=True)
 
         for f, ct in files:
-            if RegexMatch(rf"^({self.Name})_(\d+)\\.(conf)$", f):
-                s = re.search(rf"^({self.Name})_(\d+)\\.(conf)$", f)
+            if RegexMatch(rf"^({self.Name})_(\d+)\.(conf)$", f):
+                s = re.search(rf"^({self.Name})_(\d+)\.(conf)$", f)
                 date = s.group(2)
                 d = {
                     "filename": f,

--- a/src/modules/WireguardConfiguration.py
+++ b/src/modules/WireguardConfiguration.py
@@ -316,7 +316,8 @@ class WireguardConfiguration:
             f'{dbName}_history_endpoint', self.metadata,
             sqlalchemy.Column('id', sqlalchemy.String(255), nullable=False),
             sqlalchemy.Column('endpoint', sqlalchemy.String(255), nullable=False),
-            sqlalchemy.Column('time', time_col_type)
+            sqlalchemy.Column('time', time_col_type),
+            extend_existing=True
         )
         
         self.infoTable = sqlalchemy.Table(


### PR DESCRIPTION
This PR fixes three related issues upon error in the configuration backup/restore flow:

1. Fix backup filename regex — the previous raw f-string fix commit b9c271f overlooked the literal backslash, causing no backup to show up
2. Delete paired `.sql` file when removing a backup — previously only the `.conf` backup was deleted, leaving the `.sql` file there
3. Fix restore backup metadata conflict — `restoreBackup()` calls `createDatabase()` on an existing metadata instance. `peersHistoryEndpointTable` was missing `extend_existing=True`, causing restore function failed with:
```
InvalidRequestError: Table 'xxx_history_endpoint' is already defined for this MetaData instance.
```

Fixes #1256