### PR TITLE
Fix: Adding a peer with a preshared key fails with "Internal server error"

### DIFF
--- a/src/modules/AmneziaConfiguration.py
+++ b/src/modules/AmneziaConfiguration.py
@@ -1,7 +1,7 @@
 """
 AmneziaWG Configuration
 """
-import random, sqlalchemy, os, subprocess, re, uuid
+import sqlalchemy, subprocess, re, traceback
 from flask import current_app
 from .PeerJobs import PeerJobs
 from .AmneziaPeer import AmneziaPeer
@@ -279,17 +279,8 @@ class AmneziaConfiguration(WireguardConfiguration):
                     )
             for p in peers:
                 presharedKeyExist = len(p['preshared_key']) > 0
-                rd = random.Random()
-                uid = str(uuid.UUID(int=rd.getrandbits(128), version=4))
-                if presharedKeyExist:
-                    with open(uid, "w+") as f:
-                        f.write(p['preshared_key'])
-
-                command = [self.Protocol, "set", self.Name, "peer", p['id'], "allowed-ips", cleanedAllowedIPs[p["id"]], "preshared-key", uid if presharedKeyExist else "/dev/null"]
-                subprocess.check_output(command, stderr=subprocess.STDOUT)
-
-                if presharedKeyExist:
-                    os.remove(uid)
+                command = [self.Protocol, "set", self.Name, "peer", p['id'], "allowed-ips", cleanedAllowedIPs[p["id"]], "preshared-key", "/dev/stdin" if presharedKeyExist else "/dev/null"]
+                subprocess.check_output(command, input=p['preshared_key'].encode() if presharedKeyExist else None, stderr=subprocess.STDOUT)
 
             command = [f"{self.Protocol}-quick", "save", self.Name]
             subprocess.check_output(command, stderr=subprocess.STDOUT)
@@ -304,7 +295,8 @@ class AmneziaConfiguration(WireguardConfiguration):
                 "peers": list(map(lambda k : k['id'], peers))
             })
         except Exception as e:
-            current_app.logger.error("Add peers error", e)
+            output = e.output.decode('UTF-8', 'replace') if isinstance(e, subprocess.CalledProcessError) and e.output else ""
+            current_app.logger.error(f"Add peers error: {e}\n{output}\n{traceback.format_exc()}")
             return False, [], "Internal server error"
         return True, result['peers'], ""
 

--- a/src/modules/AmneziaPeer.py
+++ b/src/modules/AmneziaPeer.py
@@ -1,9 +1,6 @@
-import os
 from flask import current_app
-import random
 import re
 import subprocess
-import uuid
 
 from flask import current_app
 from .Peer import Peer
@@ -69,23 +66,15 @@ class AmneziaPeer(Peer):
                 return False, "Private key does not match with the public key"
     
         try:
-            rand = random.Random()
-            uid = str(uuid.UUID(int=rand.getrandbits(128), version=4))
             psk_exist = len(preshared_key) > 0
-
-            if psk_exist:
-                with open(uid, "w+") as f:
-                    f.write(preshared_key)
 
             newAllowedIPs = allowed_ip.replace(" ", "")
             if not CheckAddress(newAllowedIPs):
                 return False, "Allowed IPs entry format is incorrect"
 
-            command = [self.configuration.Protocol, "set", self.configuration.Name, "peer", self.id, "allowed-ips", newAllowedIPs, "preshared-key", uid if psk_exist else "/dev/null"]
+            command = [self.configuration.Protocol, "set", self.configuration.Name, "peer", self.id, "allowed-ips", newAllowedIPs, "preshared-key", "/dev/stdin" if psk_exist else "/dev/null"]
 
-            updateAllowedIp = subprocess.check_output(command, stderr=subprocess.STDOUT)
-
-            if psk_exist: os.remove(uid)
+            updateAllowedIp = subprocess.check_output(command, input=preshared_key.encode() if psk_exist else None, stderr=subprocess.STDOUT)
 
             if len(updateAllowedIp.decode().strip("\n")) != 0:
                 current_app.logger.error(f"Update peer failed when updating Allowed IPs.\nInput: {newAllowedIPs}\nOutput: {updateAllowedIp.decode().strip('\n')}")

--- a/src/modules/Peer.py
+++ b/src/modules/Peer.py
@@ -4,7 +4,7 @@ Peer
 import base64
 import datetime
 import json
-import os, subprocess, uuid, random, re
+import subprocess, re
 from datetime import timedelta
 
 import jinja2
@@ -106,22 +106,14 @@ class Peer:
                 return False, "Private key does not match with the public key"
 
         try:
-            rand = random.Random()
-            uid = str(uuid.UUID(int=rand.getrandbits(128), version=4))
             psk_exist = len(preshared_key) > 0
-
-            if psk_exist:
-                with open(uid, "w+") as f:
-                    f.write(preshared_key)
 
             newAllowedIPs = allowed_ip.replace(" ", "")
             if not CheckAddress(newAllowedIPs):
                     return False, "Allowed IPs entry format is incorrect"
 
-            command = [self.configuration.Protocol, "set", self.configuration.Name, "peer", self.id, "allowed-ips", newAllowedIPs, "preshared-key", uid if psk_exist else "/dev/null"]
-            updateAllowedIp = subprocess.check_output(command, stderr=subprocess.STDOUT)
-
-            if psk_exist: os.remove(uid)
+            command = [self.configuration.Protocol, "set", self.configuration.Name, "peer", self.id, "allowed-ips", newAllowedIPs, "preshared-key", "/dev/stdin" if psk_exist else "/dev/null"]
+            updateAllowedIp = subprocess.check_output(command, input=preshared_key.encode() if psk_exist else None, stderr=subprocess.STDOUT)
 
             if len(updateAllowedIp.decode().strip("\n")) != 0:
                 current_app.logger.error("Update peer failed when updating Allowed IPs")

--- a/src/modules/WireguardConfiguration.py
+++ b/src/modules/WireguardConfiguration.py
@@ -550,17 +550,9 @@ class WireguardConfiguration:
                     )
             for p in peers:
                 presharedKeyExist = len(p['preshared_key']) > 0
-                rd = random.Random()
-                uid = str(uuid.UUID(int=rd.getrandbits(128), version=4))
-                if presharedKeyExist:
-                    with open(uid, "w+") as f:
-                        f.write(p['preshared_key'])
 
-                command = [self.Protocol, "set", self.Name, "peer", p['id'], "allowed-ips", cleanedAllowedIPs[p["id"]], "preshared-key", uid if presharedKeyExist else "/dev/null"]
-                subprocess.check_output(command, stderr=subprocess.STDOUT)
-
-                if presharedKeyExist:
-                    os.remove(uid)
+                command = [self.Protocol, "set", self.Name, "peer", p['id'], "allowed-ips", cleanedAllowedIPs[p["id"]], "preshared-key", "/dev/stdin" if presharedKeyExist else "/dev/null"]
+                subprocess.check_output(command, input=p['preshared_key'].encode() if presharedKeyExist else None, stderr=subprocess.STDOUT)
 
             command = [f"{self.Protocol}-quick", "save", self.Name]
             subprocess.check_output(command, stderr=subprocess.STDOUT)
@@ -575,7 +567,8 @@ class WireguardConfiguration:
                 "peers": list(map(lambda k : k['id'], peers))
             })
         except Exception as e:
-            current_app.logger.error("Add peers error", e)
+            output = e.output.decode('UTF-8', 'replace') if isinstance(e, subprocess.CalledProcessError) and e.output else ""
+            current_app.logger.error(f"Add peers error: {e}\n{output}\n{traceback.format_exc()}")
             return False, [], "Internal server error"
         return True, result['peers'], ""
 
@@ -608,11 +601,6 @@ class WireguardConfiguration:
                     )
 
                     presharedKeyExist = len(restrictedPeer['preshared_key']) > 0
-                    rd = random.Random()
-                    uid = str(uuid.UUID(int=rd.getrandbits(128), version=4))
-                    if presharedKeyExist:
-                        with open(uid, "w+") as f:
-                            f.write(restrictedPeer['preshared_key'])
 
                     newAllowedIPs = restrictedPeer['allowed_ip'].replace(" ", "")
                     if not CheckAddress(newAllowedIPs):
@@ -621,10 +609,8 @@ class WireguardConfiguration:
                     if not CheckPeerKey(restrictedPeer["id"]):
                         return False, "Peer key format is incorrect"
 
-                    command = [self.Protocol, "set", self.Name, "peer", restrictedPeer["id"], "allowed-ips", newAllowedIPs, "preshared-key", uid if presharedKeyExist else "/dev/null"]
-                    subprocess.check_output(command, stderr=subprocess.STDOUT)
-
-                    if presharedKeyExist: os.remove(uid)
+                    command = [self.Protocol, "set", self.Name, "peer", restrictedPeer["id"], "allowed-ips", newAllowedIPs, "preshared-key", "/dev/stdin" if presharedKeyExist else "/dev/null"]
+                    subprocess.check_output(command, input=restrictedPeer['preshared_key'].encode() if presharedKeyExist else None, stderr=subprocess.STDOUT)
                 else:
                     return False, "Failed to allow access of peer " + i
         if not self.__wgSave():


### PR DESCRIPTION
## What's broken
Adding or updating a peer with a preshared key returns `Internal server error`. The peer shows up in the dashboard, but it can't connect. Without a preshared key, there are no error when creating users.

## Why
The code wrote the preshared key to a temp file and passed the path to `wg set ... preshared-key <file>`. `wg` couldn't read that file:
- It was written to a relative path in the process's working directory, so `open()` failed when that directory wasn't writable.
- With an absolute path in `/tmp`, the AppArmor profile shipped with `wireguard-tools` blocks `wg` from reading `/tmp`: apparmor="DENIED" operation="open" profile="wg" name="/tmp/…" comm="wg"

The write happens after the DB insert but before `wg set`, which is why the peer gets saved but never reaches the interface.

## The fix
Pipe the key to `wg` over stdin (`preshared-key /dev/stdin`) instead of writing a file. The stdin fd is open before `wg` starts, so no sandbox can block it, there's nothing to clean up, and the key never touches disk. The no-key path still uses `/dev/null`. Changed in `addPeers`, `allowAccessPeers`, and `updatePeer`, for both WireGuard and AmneziaWG.

Also fixed the `addPeers` error handler: `logger.error("Add peers error", e)`, which throws inside logging and dropped the traceback. That's why the only symptom was a bare "Internal server error". It now logs the traceback and `wg`'s stderr.

## Testing
- On an AppArmor-confined host, `/dev/stdin` succeeds where the temp file returned `fopen: Permission denied`.
- In a container with kernel WireGuard: add with and without a key, bulk add, restricted-peer re-enable, and update-to-add-key all work, the key lands on the interface.