### PR TITLE
fix: crash when password length >72 bytes.

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,7 +7,7 @@ trap 'stop_service' SIGTERM
 
 # Hash password with bcrypt
 hash_password() {
-  ${WGDASH}/src/venv/bin/python3 -c "import bcrypt; print(bcrypt.hashpw('$1'.encode(), bcrypt.gensalt(12)).decode())"
+  "${WGDASH}"/src/venv/bin/python3 -c "import bcrypt, hashlib, base64; print(bcrypt.hashpw(base64.b64encode(hashlib.sha256(\"$1\".encode(\"utf-8\")).digest()), bcrypt.gensalt(12)).decode()\"utf-8\")"
 }
 
 # Function to set or update section/key/value in the INI file

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1,6 +1,6 @@
 import logging
 import random, shutil, sqlite3, configparser, hashlib, ipaddress, json, os, secrets, subprocess
-import time, re, uuid, bcrypt, psutil, pyotp, threading
+import time, re, uuid, bcrypt, psutil, pyotp, threading, hashlib, base64
 import traceback
 from functools import wraps
 from urllib.parse import unquote
@@ -366,7 +366,8 @@ def API_AuthenticateLogin():
         resp.set_cookie("authToken", authToken)
         session.permanent = True
         return resp
-    valid = bcrypt.checkpw(data['password'].encode("utf-8"),
+    encodePassword = base64.b64encode(hashlib.sha256(data['password'].encode("utf-8")).digest())
+    valid = bcrypt.checkpw(encodePassword,
                            DashboardConfig.GetConfig("Account", "password")[1].encode("utf-8"))
     totpEnabled = DashboardConfig.GetConfig("Account", "enable_totp")[1]
     totpValid = False

--- a/src/modules/DashboardClients.py
+++ b/src/modules/DashboardClients.py
@@ -3,7 +3,7 @@ import hashlib
 import random
 import uuid
 
-import bcrypt
+import bcrypt, base64, hashlib
 import pyotp
 import sqlalchemy as db
 import requests
@@ -147,7 +147,8 @@ class DashboardClients:
             return False
         existingClient = self.SignIn_UserExistence(Email)
         if existingClient:
-            return bcrypt.checkpw(Password.encode("utf-8"), existingClient.get("Password").encode("utf-8"))            
+            encodePassword = base64.b64encode(hashlib.sha256(Password.encode("utf-8")).digest())
+            return bcrypt.checkpw(encodePassword, existingClient.get("Password").encode("utf-8"))
         return False
         
     def SignIn_UserExistence(self, Email):
@@ -280,7 +281,7 @@ class DashboardClients:
             with self.engine.begin() as conn:
                 newClientUUID = str(uuid.uuid4())
                 totpKey = pyotp.random_base32()
-                encodePassword = Password.encode('utf-8')
+                encodePassword = base64.b64encode(hashlib.sha256(Password.encode('utf-8')).digest())
                 conn.execute(
                     self.dashboardClientsTable.insert().values({
                         "ClientID": newClientUUID,
@@ -318,11 +319,12 @@ class DashboardClients:
             return pwStrength, msg
         try:
             with self.engine.begin() as conn:
+                encodeNewPassword = base64.b64encode(hashlib.sha256(NewPassword.encode('utf-8')).digest())
                 conn.execute(
                     self.dashboardClientsTable.update().values({
                         "TotpKeyVerified": None,
                         "TotpKey": pyotp.random_base32(),
-                        "Password": bcrypt.hashpw(NewPassword.encode('utf-8'), bcrypt.gensalt()).decode("utf-8"),
+                        "Password": bcrypt.hashpw(encodeNewPassword, bcrypt.gensalt()).decode("utf-8"),
                     }).where(
                         self.dashboardClientsTable.c.ClientID == ClientID
                     )
@@ -354,9 +356,10 @@ class DashboardClients:
             return pwStrength, msg
         try:
             with self.engine.begin() as conn:
+                encodeNewPassword = base64.b64encode(hashlib.sha256(NewPassword.encode('utf-8')).digest())
                 conn.execute(
                     self.dashboardClientsTable.update().values({
-                        "Password": bcrypt.hashpw(NewPassword.encode('utf-8'), bcrypt.gensalt()).decode("utf-8"),
+                        "Password": bcrypt.hashpw(encodeNewPassword, bcrypt.gensalt()).decode("utf-8"),
                     }).where(
                         self.dashboardClientsTable.c.ClientID == ClientID
                     )
@@ -495,4 +498,3 @@ class DashboardClients:
     
     def UnassignClient(self, AssignmentID):
         return self.DashboardClientsPeerAssignment.UnassignClients(AssignmentID)
-        

--- a/src/modules/DashboardConfig.py
+++ b/src/modules/DashboardConfig.py
@@ -1,7 +1,7 @@
 """
 Dashboard Configuration
 """
-import configparser, secrets, os, pyotp, ipaddress, bcrypt
+import configparser, secrets, os, pyotp, ipaddress, bcrypt, base64, hashlib
 from sqlalchemy_utils import database_exists, create_database
 import sqlalchemy as db
 from datetime import datetime
@@ -244,10 +244,10 @@ class DashboardConfig:
         return True, ""
 
     def generatePassword(self, plainTextPassword: str):
-        return bcrypt.hashpw(plainTextPassword.encode("utf-8"), bcrypt.gensalt())
+        return bcrypt.hashpw(base64.b64encode(hashlib.sha256(plainTextPassword.encode("utf-8")).digest()), bcrypt.gensalt())
 
     def __checkPassword(self, plainTextPassword: str, hashedPassword: bytes):
-        return bcrypt.checkpw(plainTextPassword.encode("utf-8"), hashedPassword)
+        return bcrypt.checkpw(base64.b64encode(hashlib.sha256(plainTextPassword.encode("utf-8")).digest()), hashedPassword)
 
     def SetConfig(self, section: str, key: str, value: str | bool | list[str] | dict[str, str], init: bool = False) -> tuple[bool, str] | tuple[bool, None]:
         if key in self.hiddenAttribute and not init:

--- a/templates/wg-dashboard.ini.template
+++ b/templates/wg-dashboard.ini.template
@@ -23,7 +23,7 @@ dashboard_language = en-US
 
 [Account]
 username = admin
-password = $2b$12$nWgPW.4adylN2oMhTyS5AeoiAvDj9SZxnXS.lCMkJYCV6jytmHKzu
+password = $2b$12$9OxPP./p8SXAXFVtDaaQ2uMWzwbE2TEACKfNdLwLtxn1d.o8jxlAa
 enable_totp = false
 totp_verified = false
 totp_key = UOXAUPDDUNFTTHXZNQI4J4BWCEJZ63HF


### PR DESCRIPTION
Fixes wgdashboard/wgdashboard#1344. Implemented hashpw and checkpw as recommended by the pyca/bcrypt maintainers.

All instances of
`bcrypt.hashpw(passwd.encode(), bcrypt.gensalt())`
changed to
`bcrypt.hashpw(base64.b64encode(hashlib.sha256(passwd.encode()).digest()), bcrypt.gensalt())`

I also modified wg-dashboard.ini.template with a hash of "admin" using the new hashing scheme.

Keep in mind, all previously generated hashes will not work with this new implementation since it hashes a SHA256 digest instead of the literal password. Please clean out your docker volume cache to test properly. I have gone ahead and independently tested the admin dashboard login on my end and things seem to be working.